### PR TITLE
Add media_metadata to post 

### DIFF
--- a/reddit/media_metadata_test.go
+++ b/reddit/media_metadata_test.go
@@ -1,0 +1,194 @@
+package reddit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPostMediaMetadata(t *testing.T) {
+	// Sample JSON data with media_metadata
+	jsonData := `{
+		"kind": "t3",
+		"data": {
+			"id": "gallerytest",
+			"title": "Test Gallery Post",
+			"is_gallery": true,
+			"media_metadata": {
+				"abc123def456": {
+					"status": "valid",
+					"e": "Image",
+					"m": "image/jpg",
+					"p": [
+						{
+							"y": 108,
+							"x": 108,
+							"u": "https://preview.redd.it/abc123def456.jpg?width=108"
+						},
+						{
+							"y": 216,
+							"x": 216,
+							"u": "https://preview.redd.it/abc123def456.jpg?width=216"
+						}
+					],
+					"s": {
+						"y": 2048,
+						"x": 1536,
+						"u": "https://i.redd.it/abc123def456.jpg"
+					},
+					"id": "abc123def456"
+				},
+				"xyz789ghi012": {
+					"status": "valid",
+					"e": "AnimatedImage",
+					"m": "image/gif",
+					"p": [
+						{
+							"y": 108,
+							"x": 192,
+							"u": "https://preview.redd.it/xyz789ghi012.gif?width=108"
+						}
+					],
+					"s": {
+						"y": 1080,
+						"x": 1920,
+						"u": "https://i.redd.it/xyz789ghi012.gif",
+						"gif": "https://i.redd.it/xyz789ghi012.gif",
+						"mp4": "https://v.redd.it/xyz789ghi012.mp4"
+					},
+					"id": "xyz789ghi012"
+				}
+			},
+			"gallery_data": {
+				"items": [
+					{
+						"media_id": "abc123def456",
+						"id": 1,
+						"caption": "First image in the gallery"
+					},
+					{
+						"media_id": "xyz789ghi012",
+						"id": 2,
+						"caption": "Cool animated GIF"
+					}
+				]
+			}
+		}
+	}`
+
+	var thing thing
+	err := json.Unmarshal([]byte(jsonData), &thing)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	post, ok := thing.Data.(*Post)
+	if !ok {
+		t.Fatal("Expected Post data")
+	}
+
+	// Test IsGallery
+	if !post.IsGallery {
+		t.Error("Expected post to be a gallery")
+	}
+
+	// Test MediaMetadata
+	if post.MediaMetadata == nil {
+		t.Fatal("Expected media metadata to be present")
+	}
+
+	if len(post.MediaMetadata) != 2 {
+		t.Errorf("Expected 2 media items, got %d", len(post.MediaMetadata))
+	}
+
+	// Test direct access to MediaMetadata
+	firstMedia := post.MediaMetadata["abc123def456"]
+	if firstMedia == nil {
+		t.Fatal("Expected to find media item abc123def456")
+	}
+
+	if firstMedia.E != "Image" {
+		t.Errorf("Expected media type Image, got %s", firstMedia.E)
+	}
+
+	if firstMedia.M != "image/jpg" {
+		t.Errorf("Expected MIME type image/jpg, got %s", firstMedia.M)
+	}
+
+	// Test media source URL access
+	if firstMedia.S.U != "https://i.redd.it/abc123def456.jpg" {
+		t.Errorf("Expected source URL https://i.redd.it/abc123def456.jpg, got %s", firstMedia.S.U)
+	}
+
+	// Test preview images
+	if len(firstMedia.P) != 2 {
+		t.Errorf("Expected 2 preview images, got %d", len(firstMedia.P))
+	}
+
+	if len(firstMedia.P) > 0 && firstMedia.P[0].U != "https://preview.redd.it/abc123def456.jpg?width=108" {
+		t.Errorf("Expected first preview URL https://preview.redd.it/abc123def456.jpg?width=108, got %s", firstMedia.P[0].U)
+	}
+
+	// Test animated media
+	animatedMedia := post.MediaMetadata["xyz789ghi012"]
+	if animatedMedia == nil {
+		t.Fatal("Expected to find animated media item xyz789ghi012")
+	}
+
+	if animatedMedia.E != "AnimatedImage" {
+		t.Error("Expected animated media to have type AnimatedImage")
+	}
+
+	if animatedMedia.S.MP4 != "https://v.redd.it/xyz789ghi012.mp4" {
+		t.Errorf("Expected MP4 URL https://v.redd.it/xyz789ghi012.mp4, got %s", animatedMedia.S.MP4)
+	}
+
+	// Test GalleryData
+	if post.GalleryData == nil {
+		t.Fatal("Expected gallery data to be present")
+	}
+
+	galleryItems := post.GalleryData.Items
+	if len(galleryItems) != 2 {
+		t.Errorf("Expected 2 gallery items, got %d", len(galleryItems))
+	}
+
+	if galleryItems[0].MediaID != "abc123def456" {
+		t.Errorf("Expected first gallery item media ID abc123def456, got %s", galleryItems[0].MediaID)
+	}
+
+	if galleryItems[0].Caption != "First image in the gallery" {
+		t.Errorf("Expected first gallery item caption 'First image in the gallery', got %s", galleryItems[0].Caption)
+	}
+
+	if galleryItems[1].MediaID != "xyz789ghi012" {
+		t.Errorf("Expected second gallery item media ID xyz789ghi012, got %s", galleryItems[1].MediaID)
+	}
+}
+
+func TestPostMediaMetadataEdgeCases(t *testing.T) {
+	// Test post without media metadata
+	post := &Post{}
+
+	if post.MediaMetadata != nil {
+		t.Error("Expected nil media metadata for empty post")
+	}
+
+	if post.GalleryData != nil {
+		t.Error("Expected nil gallery data for empty post")
+	}
+
+	if !post.IsGallery {
+		// This is expected - IsGallery should be false for non-gallery posts
+	}
+
+	// Test post with empty media metadata
+	post.MediaMetadata = make(map[string]*MediaMetadataItem)
+
+	if len(post.MediaMetadata) != 0 {
+		t.Error("Expected empty media metadata map")
+	}
+
+	if post.MediaMetadata["nonexistent"] != nil {
+		t.Error("Expected nil for non-existent media in empty metadata")
+	}
+}

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -574,8 +574,46 @@ type Post struct {
 	Removed     *bool   `json:"removed,omitempty"`
 	RemovedBy   *string `json:"removed_by"`
 	ModReasonBy *string `json:"mod_reason_by"`
+
+	
+	// Gallery related fields
+	IsGallery     bool                          `json:"is_gallery"`
+	MediaMetadata map[string]*MediaMetadataItem `json:"media_metadata"`
+	GalleryData   *GalleryData                  `json:"gallery_data"`
 }
 
+// MediaMetadataItem represents metadata for a media item in a gallery or post
+type MediaMetadataItem struct {
+	Status string `json:"status"`
+	E      string `json:"e"` // media type, e.g., "Image", "AnimatedImage", "RedditVideo"
+	M      string `json:"m"` // MIME type, e.g., "image/jpg", "image/png", "image/gif"
+	P      []struct {
+		Y int    `json:"y"` // height
+		X int    `json:"x"` // width
+		U string `json:"u"` // URL
+	} `json:"p"` // preview images
+	S struct {
+		Y   int    `json:"y"`             // height
+		X   int    `json:"x"`             // width
+		U   string `json:"u"`             // URL
+		GIF string `json:"gif,omitempty"` // GIF URL for animated images
+		MP4 string `json:"mp4,omitempty"` // MP4 URL for videos
+	} `json:"s"` // source image/video
+	ID string `json:"id"` // media ID
+}
+
+// GalleryData represents the gallery data structure containing ordered media items
+type GalleryData struct {
+	Items []GalleryItem `json:"items"`
+}
+
+// GalleryItem represents a single item in a gallery
+type GalleryItem struct {
+	MediaID     string `json:"media_id"`
+	ID          int    `json:"id"`
+	Caption     string `json:"caption,omitempty"`
+	OutboundURL string `json:"outbound_url,omitempty"`
+}
 // Subreddit holds information about a subreddit
 type Subreddit struct {
 	ID      string     `json:"id,omitempty"`

--- a/testdata/post/gallery.json
+++ b/testdata/post/gallery.json
@@ -1,0 +1,219 @@
+{
+  "kind": "Listing",
+  "data": {
+    "modhash": null,
+    "dist": 1,
+    "children": [
+      {
+        "kind": "t3",
+        "data": {
+          "approved_at_utc": null,
+          "subreddit": "pics",
+          "selftext": "",
+          "author_fullname": "t2_testuser",
+          "saved": false,
+          "mod_reason_title": null,
+          "gilded": 0,
+          "clicked": false,
+          "title": "Test Gallery Post",
+          "link_flair_richtext": [],
+          "subreddit_name_prefixed": "r/pics",
+          "hidden": false,
+          "pwls": 6,
+          "link_flair_css_class": null,
+          "downs": 0,
+          "thumbnail_height": 140,
+          "top_awarded_type": null,
+          "hide_score": false,
+          "name": "t3_gallerytest",
+          "quarantine": false,
+          "link_flair_text_color": "dark",
+          "upvote_ratio": 0.95,
+          "author_flair_background_color": null,
+          "subreddit_type": "public",
+          "ups": 1250,
+          "total_awards_received": 3,
+          "media_embed": {},
+          "thumbnail_width": 140,
+          "author_flair_template_id": null,
+          "is_original_content": false,
+          "user_reports": [],
+          "secure_media": null,
+          "is_reddit_media_domain": true,
+          "is_meta": false,
+          "category": null,
+          "secure_media_embed": {},
+          "link_flair_text": null,
+          "can_mod_post": false,
+          "score": 1250,
+          "approved_by": null,
+          "author_premium": false,
+          "thumbnail": "https://b.thumbs.redditmedia.com/gallery_thumb.jpg",
+          "edited": false,
+          "author_flair_css_class": null,
+          "author_flair_richtext": [],
+          "gildings": {},
+          "post_hint": "image",
+          "content_categories": null,
+          "is_self": false,
+          "mod_note": null,
+          "created": 1629825600.0,
+          "link_flair_type": "text",
+          "wls": 6,
+          "removed_by_category": null,
+          "banned_by": null,
+          "author_flair_type": "text",
+          "domain": "reddit.com",
+          "allow_live_comments": false,
+          "selftext_html": null,
+          "likes": null,
+          "suggested_sort": null,
+          "banned_at_utc": null,
+          "view_count": null,
+          "archived": false,
+          "no_follow": false,
+          "is_crosspostable": true,
+          "pinned": false,
+          "over_18": false,
+          "all_awardings": [],
+          "awarders": [],
+          "media_only": false,
+          "can_gild": true,
+          "spoiler": false,
+          "locked": false,
+          "author_flair_text": null,
+          "treatment_tags": [],
+          "visited": false,
+          "removed_by": null,
+          "num_reports": null,
+          "distinguished": null,
+          "subreddit_id": "t5_2qh0u",
+          "mod_reason_by": null,
+          "removal_reason": null,
+          "link_flair_background_color": "",
+          "id": "gallerytest",
+          "is_robot_indexable": true,
+          "report_reasons": null,
+          "author": "testuser",
+          "discussion_type": null,
+          "num_comments": 42,
+          "send_replies": true,
+          "whitelist_status": "all_ads",
+          "contest_mode": false,
+          "mod_reports": [],
+          "author_patreon_flair": false,
+          "author_flair_text_color": null,
+          "permalink": "/r/pics/comments/gallerytest/test_gallery_post/",
+          "parent_whitelist_status": "all_ads",
+          "stickied": false,
+          "url": "https://www.reddit.com/gallery/gallerytest",
+          "subreddit_subscribers": 25000000,
+          "created_utc": 1629825600.0,
+          "num_crossposts": 2,
+          "media": null,
+          "is_video": false,
+          "is_gallery": true,
+          "media_metadata": {
+            "abc123def456": {
+              "status": "valid",
+              "e": "Image",
+              "m": "image/jpg",
+              "p": [
+                {
+                  "y": 108,
+                  "x": 108,
+                  "u": "https://preview.redd.it/abc123def456.jpg?width=108&crop=smart&auto=webp&s=abc123"
+                },
+                {
+                  "y": 216,
+                  "x": 216,
+                  "u": "https://preview.redd.it/abc123def456.jpg?width=216&crop=smart&auto=webp&s=def456"
+                },
+                {
+                  "y": 320,
+                  "x": 320,
+                  "u": "https://preview.redd.it/abc123def456.jpg?width=320&crop=smart&auto=webp&s=ghi789"
+                }
+              ],
+              "s": {
+                "y": 2048,
+                "x": 1536,
+                "u": "https://i.redd.it/abc123def456.jpg"
+              },
+              "id": "abc123def456"
+            },
+            "xyz789ghi012": {
+              "status": "valid",
+              "e": "AnimatedImage",
+              "m": "image/gif",
+              "p": [
+                {
+                  "y": 108,
+                  "x": 192,
+                  "u": "https://preview.redd.it/xyz789ghi012.gif?width=108&crop=smart&auto=webp&s=xyz789"
+                },
+                {
+                  "y": 216,
+                  "x": 384,
+                  "u": "https://preview.redd.it/xyz789ghi012.gif?width=216&crop=smart&auto=webp&s=ghi012"
+                }
+              ],
+              "s": {
+                "y": 1080,
+                "x": 1920,
+                "u": "https://i.redd.it/xyz789ghi012.gif",
+                "gif": "https://i.redd.it/xyz789ghi012.gif",
+                "mp4": "https://v.redd.it/xyz789ghi012.mp4"
+              },
+              "id": "xyz789ghi012"
+            },
+            "def456abc789": {
+              "status": "valid",
+              "e": "Image",
+              "m": "image/png",
+              "p": [
+                {
+                  "y": 108,
+                  "x": 144,
+                  "u": "https://preview.redd.it/def456abc789.png?width=108&crop=smart&auto=webp&s=def456"
+                },
+                {
+                  "y": 216,
+                  "x": 288,
+                  "u": "https://preview.redd.it/def456abc789.png?width=216&crop=smart&auto=webp&s=abc789"
+                }
+              ],
+              "s": {
+                "y": 1440,
+                "x": 1920,
+                "u": "https://i.redd.it/def456abc789.png"
+              },
+              "id": "def456abc789"
+            }
+          },
+          "gallery_data": {
+            "items": [
+              {
+                "media_id": "abc123def456",
+                "id": 1,
+                "caption": "First image in the gallery"
+              },
+              {
+                "media_id": "xyz789ghi012",
+                "id": 2,
+                "caption": "Cool animated GIF",
+                "outbound_url": "https://example.com/source"
+              },
+              {
+                "media_id": "def456abc789",
+                "id": 3
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "after": null,
+    "before": null
+  }
+}


### PR DESCRIPTION
This pull request adds support for Reddit gallery posts by introducing new fields and types to represent gallery data and media metadata on posts. 

**Gallery and Media Metadata Support:**

* Added new fields to the `Post` struct: `IsGallery`, `MediaMetadata`, and `GalleryData`, enabling the representation of Reddit gallery posts and their associated media items.
* Introduced new types: `MediaMetadataItem`, `GalleryData`, and `GalleryItem` to model the structure of media metadata and gallery data as returned by Reddit's API.

**Testing:**

* Added `reddit/media_metadata_test.go`, a new test file with unit tests that verify correct parsing and access of gallery post fields, media metadata, and edge cases such as missing or empty metadata.

**Test Data:**

* Added a new test data file `testdata/post/gallery.json` containing a mock Reddit gallery post with multiple media items, including images and an animated GIF, to facilitate testing of the new functionality.